### PR TITLE
Readme about building with clang openmp on macosx

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,23 @@ $ pip install . --upgrade
 # Run tests
 $ py.test
 ```
+
+### Mac OS X and OpenMP
+
+It isn't that hard to get parallel process support working on MacOSX.
+
+```bash
+
+# get the clang compiler with OpenMP support 
+brew install clang-omp
+
+# build the package using clang compilers with OpenMP support
+CXX=/usr/local/bin/clang-omp CC=/usr/local/bin/clang-omp pip install . --upgrade
+
+# test the primesieve library uses multiple cores.
+# run this and check Activity Monitor for multiple threads
+python -c 'import primesieve as ps; n=ps.parallel_count_primes(10**10); print(n)'
+455052511
+```
+
+

--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ $ pip install . --upgrade
 $ py.test
 ```
 
-### Mac OS X and OpenMP
+#### Mac OS X and OpenMP
 
-It isn't that hard to get parallel process support working on MacOSX.
+It isn't that hard to get parallel process support working on MacOSX. You'll need to install the clang compiler that supports OpenMP. Instead of the pip install step above, do the following steps.
 
 ```bash
 


### PR DESCRIPTION
This just adds a note about how to build with OpenMP support on MacOSX to get parallel primes counting. 

@kimwalisch - this works for me. I assume you're more up-to-date on what is going on with clang support for OpenMP. The brew package for clang-omp is easy to install and use. Are there any caveats I'm missing?
