### PR TITLE
Include the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include LICENSE
 graft lib


### PR DESCRIPTION
Adds the license file to `MANIFEST.in` so that it can be included in `sdist`s and related package.
