### PR TITLE
Fix gcc error when openmp-dev is not installed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ omp_test = \
     """
 
 def get_compiler_openmp_flag():
-    openmp_flag = ''
+    openmp_flags = []
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()
     os.chdir(tmpdir)
@@ -65,24 +65,25 @@ def get_compiler_openmp_flag():
         except:
             pass
         if exit_code == 0:
-            openmp_flag = '-fopenmp'
+            openmp_flags = ['-fopenmp']
         else:
             try:
                 exit_code = subprocess.call([cc, '/openmp', filename], stdout=fnull, stderr=fnull)
             except:
                 pass
             if exit_code == 0:
-                openmp_flag = '/openmp'
+                openmp_flags = ['/openmp']
 
     #clean up
     os.chdir(curdir)
     shutil.rmtree(tmpdir)
-    return openmp_flag
+    return openmp_flags
 
-openmp_flag = get_compiler_openmp_flag()
-print('get_compiler_openmp_flag(): ' + openmp_flag)
-extra_compile_args.append(openmp_flag)
-extra_link_args.append(openmp_flag)
+openmp_flags = get_compiler_openmp_flag()
+print('get_compiler_openmp_flag(): ' + ' '.join(openmp_flags))
+for flag in openmp_flags:
+    extra_compile_args.append(flag)
+    extra_link_args.append(flag)
 
 # ------------------ Check if NumPy is installed --------------------
 


### PR DESCRIPTION
With libgomp-devel python setup.py gives me this empty gcc warning due to
an empty string arg.

This was detected as part of packing primesieve-py for https://www.mageia.org/en/ .

shlomif@telaviv1:~/Download/unpack/prog/python/primesieve-python$ python setup.py bdist
get_compiler_openmp_flag():
running bdist
running bdist_dumb
running build
running build_py
creating build
creating build/lib.linux-x86_64-2.7
creating build/lib.linux-x86_64-2.7/primesieve
copying primesieve/__init__.py -> build/lib.linux-x86_64-2.7/primesieve
creating build/lib.linux-x86_64-2.7/primesieve/numpy
copying primesieve/numpy/__init__.py -> build/lib.linux-x86_64-2.7/primesieve/numpy
running build_ext
building 'primesieve._primesieve' extension
creating build/temp.linux-x86_64-2.7
creating build/temp.linux-x86_64-2.7/primesieve
gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables -I/usr/include/ncursesw -DNDEBUG -O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables -g -fPIC -Ilib/primesieve/include -I/usr/include/python2.7 -c primesieve/_primesieve.cpp -o build/temp.linux-x86_64-2.7/primesieve/_primesieve.o
gcc: error: : No such file or directory
error: command 'gcc' failed with exit status 1
shlomif@telaviv1:~/Download/unpack/prog/python/primesieve-python$