### PR TITLE
Remove -lprimesieve on non-Windows platforms.

### DIFF
--- a/primesieve/_primesieve.pyx
+++ b/primesieve/_primesieve.pyx
@@ -198,7 +198,7 @@ cdef class Iterator:
     def __cinit__(self):
         self._iterator = cpp_primesieve.iterator()
     cpdef void skipto(self, uint64_t start, uint64_t stop_hint = 2**62) except +:
-        self._iterator.skipto(start, stop_hint)
+        cpp_primesieve.iterator_jumpto(self._iterator, start+1, stop_hint)
     cpdef uint64_t next_prime(self) except +:
         return self._iterator.next_prime()
     cpdef uint64_t prev_prime(self) except +:

--- a/primesieve/cpp_primesieve.pxd
+++ b/primesieve/cpp_primesieve.pxd
@@ -31,6 +31,16 @@ cdef extern from "primesieve/iterator.hpp" namespace "primesieve":
     cdef cppclass iterator:
         iterator()
         iterator(uint64_t start, uint64_t stop_hint)
-        void skipto(uint64_t start, uint64_t stop_hint)
+        # void jump_to(uint64_t start, uint64_t stop_hint)
         uint64_t next_prime()
         uint64_t prev_prime()
+
+cdef extern from *:
+    '''
+    #if PRIMESIEVE_VERSION_MAJOR >= 11
+    #define iterator_jumpto(it, start, hint) it.jump_to(start, hint)
+    #else
+    #define iterator_jumpto(it, start, hint) it.skipto(start-1, hint)
+    #endif
+    '''
+    void iterator_jumpto(iterator & it, uint64_t start, uint64_t stop_hint)

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ else:
 
 setup(
     name='primesieve',
-    version='2.3.1',
+    version='2.3.2',
     url='https://github.com/kimwalisch/primesieve-python',
     long_description=open('README.md', "rb").read().decode('utf8'),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ extra_compile_args = []
 extra_link_args = []
 if not is_mswindows():
     extra_compile_args.append('-std=c++11')
-    extra_link_args.append('-lprimesieve')
 include_dirs = []
 
 # ------------- Check if compiler supports -pthread -----------------

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,15 @@ else:
 
 # --------------------- Initialization ------------------------------
 
+def is_mswindows():
+    """docstring for is_mswindows"""
+    return sys.platform.startswith('win')
+
+
 extensions = []
 extra_compile_args = []
 extra_link_args = []
-if not sys.platform.startswith('win'):
+if not is_mswindows():
     extra_compile_args.append('-std=c++11')
     extra_link_args.append('-lprimesieve')
 include_dirs = []

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,10 @@ else:
 
 extensions = []
 extra_compile_args = []
+extra_link_args = []
 if not sys.platform.startswith('win'):
     extra_compile_args.append('-std=c++11')
-extra_link_args = []
+    extra_link_args.append('-lprimesieve')
 include_dirs = []
 
 # ------------- Check if compiler supports -pthread -----------------

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ else:
 
 setup(
     name='primesieve',
-    version='2.3.0',
+    version='2.3.1',
     url='https://github.com/kimwalisch/primesieve-python',
     long_description=open('README.md', "rb").read().decode('utf8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Installation via pip 24.0 on Ubuntu 22.04 with Python 3.10.12 fails when unable to find primesieve library to link. Removing this linker option resolved the problem and primesieve successfully installed. These changes are untested on other platforms.